### PR TITLE
INTERLOK-4477: Upgrade jakarta/Update release version 5.1-SNAPSHOT

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -14,8 +14,8 @@ plugins {
 }
 
 ext {
-  interlokCoreVersion = project.findProperty('interlokCoreVersion') ?: '5.0-SNAPSHOT'
-  releaseVersion = project.findProperty('releaseVersion') ?: '5.0-SNAPSHOT'
+  interlokCoreVersion = project.findProperty('interlokCoreVersion') ?: '5.1-SNAPSHOT'
+  releaseVersion = project.findProperty('releaseVersion') ?: '5.1-SNAPSHOT'
   nexusBaseUrl = project.findProperty('nexusBaseUrl') ?: 'https://nexus.adaptris.net/nexus'
   mavenPublishUrl = project.findProperty('mavenPublishUrl') ?: nexusBaseUrl + '/content/repositories/snapshots'
   javadocsBaseUrl = nexusBaseUrl + "/content/sites/javadocs/com/adaptris"

--- a/src/main/java/com/adaptris/workunit/services/WorkUnitService.java
+++ b/src/main/java/com/adaptris/workunit/services/WorkUnitService.java
@@ -7,9 +7,9 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Properties;
 
-import javax.validation.Valid;
-import javax.validation.constraints.NotBlank;
-import javax.validation.constraints.NotNull;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.StringUtils;

--- a/src/main/java/com/adaptris/workunit/varsub/KeyValuePairVariableSet.java
+++ b/src/main/java/com/adaptris/workunit/varsub/KeyValuePairVariableSet.java
@@ -2,8 +2,8 @@ package com.adaptris.workunit.varsub;
 
 import java.util.Properties;
 
-import javax.validation.Valid;
-import javax.validation.constraints.NotNull;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
 
 import com.adaptris.annotation.AdapterComponent;
 import com.adaptris.annotation.ComponentProfile;

--- a/src/main/java/com/adaptris/workunit/varsub/WorkUnitVariableSet.java
+++ b/src/main/java/com/adaptris/workunit/varsub/WorkUnitVariableSet.java
@@ -3,7 +3,7 @@ package com.adaptris.workunit.varsub;
 import java.io.InputStream;
 import java.util.Properties;
 
-import javax.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotBlank;
 
 import org.apache.commons.io.FilenameUtils;
 


### PR DESCRIPTION
## Motivation

INTERLOK-4477: Upgrade jakarta and jetty, make release version 5.1-SNAPSHOT

## Modification
Updated necessary dependencies and imports to use jakarta instead of javax


## PR Checklist

- [x] been self-reviewed.
- [ ] Added javadocs for most classes and all non-trivial methods
- [ ] Added supporting annotations (like @XStreamAlias / @ComponentProfile)
- [ ] Added DefaultValue annotation when there is a default value (e.g. @DefaultValue('true'))
- [ ] Added validation annotation (@NotNull...) when required and add @Valid when nested class has some validation
- [ ] Checked that @NotNull and @NotBlank annotations have a meaningful message when appropriate.
- [ ] Checked that new 3rd party dependencies are appropriately licensed
- [ ] Added comments explaining the "why" and the intent of the code wherever it would not be obvious for an unfamiliar reader
- [ ] Added unit tests or modified existing tests to cover new code paths
- [ ] Tested new/updated components in the UI and at runtime in an Interlok instance
- [ ] Reviewed java class members so that missing annotations are added (InputFieldDefault/ComponentProfile etc)
- [ ] Checked that javadoc generation doesn't report errors
- [ ] Checked the display of the component in the UI
- [ ] Remove any config/license annotations
- [ ] Check the gradle build file to make sure the dependencies section is more explicit "implementation/api".

## Result

Compatibility with future versions of jakarta/jetty

## Testing


